### PR TITLE
Add package license metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "@dropbox/sign",
             "version": "1.11.0",
+            "license": "MIT",
             "dependencies": {
                 "axios": "^1.8.2",
                 "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "prettier": "prettier --write ./api/ ./model/"
     },
     "author": "Dropbox Sign",
+    "license": "MIT",
     "dependencies": {
         "axios": "^1.8.2",
         "bluebird": "^3.7.2",


### PR DESCRIPTION
## Summary
- add `license: "MIT"` to the npm package manifest
- keep the root package-lock metadata in sync

This matches the existing repository `LICENSE` file.

## Verification
- node manifest/lock assertion
- git diff --check
- npm pack --dry-run --json --ignore-scripts
